### PR TITLE
Check `Link.Name` instead of `Link` directly

### DIFF
--- a/templates/tmpl.html
+++ b/templates/tmpl.html
@@ -264,14 +264,14 @@
         </div>
         <!-- Contact information -->
         <div class="header-contact">
-          {{- with .Contact.Github}}
-            <span><i class="icon icon-repository"></i> <a href="{{.URL}}">{{.Name}}</a></span>
+          {{- if .Contact.Github.Name}}
+            <span><i class="icon icon-repository"></i> <a href="{{.Contact.Github.URL}}">{{.Contact.Github.Name}}</a></span>
           {{- end}}
-          {{- with .Contact.Linkedin}}
-            <span><i class="icon icon-job"></i> <a href="{{.URL}}">{{.Name}}</a></span>
+          {{- if .Contact.Linkedin.Name}}
+            <span><i class="icon icon-job"></i> <a href="{{.Contact.Linkedin.URL}}">{{.Contact.Linkedin.Name}}</a></span>
           {{- end}}
-          {{- with .Contact.Webpage}}
-            <span><i class="icon icon-webpage"></i> <a href="{{.URL}}">{{.Name}}</a></span>
+          {{- if .Contact.Webpage.Name}}
+            <span><i class="icon icon-webpage"></i> <a href="{{.Contact.Webpage.URL}}">{{.Contact.Webpage.Name}}</a></span>
           {{- end}}
           {{- with .Contact.Address}}
             <span><i class="icon icon-address"></i> {{.}}</span>


### PR DESCRIPTION
If `Link` is not defined in YAML, an icon is still shown in HTML, PDF, PNG.
Checking `.Name` in `Link` solve this issue.

Example YAML
```yaml
# Contact information
contact:
  phone: phone number
  address: home address
  webpage:
    name: webpage
    url: https://eff.org
  email: example@email.com
  github:
    name: username
    url: https://github.com/
#  linkedin:
#    name: username
#    url: https://linkedin.com/
```

Before
![image](https://user-images.githubusercontent.com/18702153/31552556-bc607978-b02f-11e7-926a-904f41a49cfa.png)

After
![image](https://user-images.githubusercontent.com/18702153/31552476-893f1af4-b02f-11e7-85c5-a5d2825321f5.png)
